### PR TITLE
--ignore_receptor bug

### DIFF
--- a/implicit_solvent_ddm/implicit_ddm_workflow.py
+++ b/implicit_solvent_ddm/implicit_ddm_workflow.py
@@ -82,7 +82,7 @@ def ddm_workflow(df_config_inputs, argSet, work_dir):
                                         argSet, "end_state", input_mdin=argSet["parameters"]["end_state_mdin"][0], work_dir=work_dir)
             
             # If the ignore_receptor flag is not called, then run long MD on receptor 
-            if not argSet["ignore_receptor"]:
+            if not argSet["parameters"]["ignore_receptor"]:
                 #run simulation for receptor only 
                 receptor_name =  re.sub(r".*/([^/.]*)\.[^.]*",r"\1",df_config_inputs['receptor_parameter_filename'][n])
                 
@@ -127,7 +127,7 @@ def ddm_workflow(df_config_inputs, argSet, work_dir):
                                                          get_output_dir(df_config_inputs['ligand_parameter_filename'][n],2), 
                                                          argSet, f"lambda_{conformational_rest}", 
                                                          work_dir=work_dir, conformational_restraint = conformational_rest)
-            if not argSet["ignore_receptor"]: 
+            if not argSet["parameters"]["ignore_receptor"]: 
                 #begin running intermidate states for receptor 
                 receptor_intermidate = split_job.addChildJobFn(run_md,
                                                             df_config_inputs['receptor_parameter_filename'][n], df_config_inputs['receptor_parameter_basename'][n],
@@ -145,7 +145,7 @@ def ddm_workflow(df_config_inputs, argSet, work_dir):
                                                               solvent_turned_off=True) 
         
         #turn off the solvent for receptor simulation with force of conformational restraints
-        if not argSet["ignore_receptor"]:
+        if not argSet["parameters"]["ignore_receptor"]:
             turn_off_solvent_receptor_job = split_job.addChildJobFn(run_md,
                                                                     df_config_inputs['receptor_parameter_filename'][n], df_config_inputs['receptor_parameter_basename'][n],
                                                                     [split_job.rv(1)], os.path.basename(str(split_job.rv(1))),
@@ -225,7 +225,7 @@ def main():
     #updates argSet to contain ligand and receptor respective topology and coordinate files. 
     
     argSet["parameters"]["mdin_intermidate_config"] = os.path.abspath(argSet["parameters"]["mdin_intermidate_config"])
-    argSet["ignore_receptor"] = options.ignore_receptor
+    argSet["parameters"]["ignore_receptor"] = options.ignore_receptor
     #create initial directory structure 
     create_dirstruct(argSet)
      

--- a/implicit_solvent_ddm/remd.py
+++ b/implicit_solvent_ddm/remd.py
@@ -62,7 +62,7 @@ def remd_workflow(job, df_config_inputs, argSet, work_dir):
         job.addChild(complex_extract)
         
         #if the ingore_receptor flag is not given then run REMD on receptor system 
-        if not argSet["ignore_receptor"]:
+        if not argSet["parameters"]["ignore_receptor"]:
             minimization_receptor = Job.wrapJobFn(run_remd, 
                                         df_config_inputs['receptor_parameter_filename'][n], df_config_inputs['receptor_coordinate_filename'][n],
                                         argSet, work_dir, "minimization")

--- a/implicit_solvent_ddm/restraints.py
+++ b/implicit_solvent_ddm/restraints.py
@@ -191,7 +191,7 @@ def write_freezing_restraints(receptor_freezing_restraints, ligand_freezing_rest
                                 +'\n'
                                 )
 
-        if not arguments["ignore_receptor"]: 
+        if not arguments["parameters"]["ignore_receptor"]: 
             #file = open(work_dir + "/mdgb/freeze_restraints_folder/"+name_of_system+"_receptor_restraint.FRST", "a+")
             file = open(work_dir + "/mdgb/freeze_restraints_folder/receptor/"+ receptor_name + "_restraint.FRST", "a+")
             file.write(rec_restraint_string)
@@ -201,7 +201,7 @@ def write_freezing_restraints(receptor_freezing_restraints, ligand_freezing_rest
         file = open(work_dir + "/mdgb/freeze_restraints_folder/complex/"+complex_name +"_restraint.FRST", "a+")
         file.write(rec_restraint_string)
         file.close()
-    if not arguments["ignore_receptor"]:
+    if not arguments["parameters"]["ignore_receptor"]:
         #file = open(work_dir + "/mdgb/freeze_restraints_folder/"+name_of_system+"_receptor_restraint.FRST", "a+")
         file = open(work_dir + "/mdgb/freeze_restraints_folder/receptor/"+receptor_name+"_restraint.FRST", "a+")
         end_string = ('&end\n')

--- a/implicit_solvent_ddm/toil_parser.py
+++ b/implicit_solvent_ddm/toil_parser.py
@@ -1,4 +1,3 @@
-
 import os, os.path
 import re 
 import pandas as pd
@@ -53,7 +52,7 @@ def input_parser(argSet, toil):
         }
         data_inputs.update(ligand_inputs)
         
-    if not argSet["ignore_receptor"]:
+    if not argSet["parameters"]["ignore_receptor"]:
         parmtop_key = 'receptor_parameter_filename'
         coordinate_key = 'receptor_coordinate_filename'
         receptor_parameter_filename, receptor_parameter_basename, receptor_coordinate_filename, receptor_coordinate_basename = getfiles(toil, argSet, parmtop_key, coordinate_key)
@@ -113,17 +112,19 @@ def get_receptor_ligand_topologies(argSet):
     argSet["ligand_parameter_filename"] = [ligand_inputs[0]]
     argSet["ligand_coordinate_filename"] = [ligand_inputs[1]]
     
-    if not argSet["ignore_receptor"]:
-        try:
-            pt.write_parm(f"{receptor_name}_{0:03}.parm7",receptor.top)
-            pt.write_traj(f"{receptor_name}_{0:03}.ncrst",receptor)
-        except:
-            sys.exit(f"The receptor file exist {receptor_name}_{0:03}. Use --ignore_receptor flag to prevent duplicate runs")
+    
+    if os.path.exists(f"{receptor_name}_{0:03}.parm7"):
+        if not argSet["parameters"]["ignore_receptor"]:
+            argSet["parameters"]["ignore_receptor"] = True
+        argSet["receptor_parameter_filename"] = [f"{receptor_name}_{0:03}.parm7"]
+    
+    else:
+        pt.write_parm(f"{receptor_name}_{0:03}.parm7",receptor.top)
+        pt.write_traj(f"{receptor_name}_{0:03}.ncrst",receptor)
+            
         receptor_inputs = (f"{receptor_name}_{0:03}.parm7", f"{receptor_name}_{0:03}.ncrst.1")
         argSet["receptor_parameter_filename"] = [receptor_inputs[0]]
         argSet["receptor_coordinate_filename"] = [receptor_inputs[1]]
-    else:
-        argSet["receptor_parameter_filename"] = [f"{receptor_name}_{0:03}.parm7"]
         
     
     return argSet


### PR DESCRIPTION
If receptor file exists the workflow will continue without  running any receptor simulations

Note: An alternative may need to be reworked in case of receptor MD failures
