### PR TITLE
number of threads for Host/Guest system

### DIFF
--- a/implicit_solvent_ddm/config.py
+++ b/implicit_solvent_ddm/config.py
@@ -125,20 +125,29 @@ class AmberMasks:
 @dataclass
 class REMD:
     ngroups: int = 0
-    nthreads: int = 0
     target_temperature: float = 0.0 
     equilibration_replica_mdins: List[str] = field(default_factory=list)
     remd_mdins: List[str]  = field(default_factory=list)
+    nthreads_complex: int = 0
+    nthreads_receptor: int = 0
+    nthreads_ligand: int = 0
+    # nthreads: int = 0
     
-    
+    def  __post_init__(self):
+        
+        if len(self.equilibration_replica_mdins) != len(self.remd_mdins):
+            raise RuntimeError(f"The size of {self.equilibration_replica_mdins} and {self.remd_mdins} do not match: {len(self.equilibration_replica_mdins)} | {len(self.remd_mdins)}")
+        
     @classmethod
     def from_config(cls: Type["REMD"], obj:dict):
         return cls(
-            nthreads = obj["endstate_arguments"]["nthreads"],
             ngroups = obj["endstate_arguments"]["ngroups"],
             target_temperature = obj["endstate_arguments"]["target_temperature"],
             equilibration_replica_mdins = obj["endstate_arguments"]["equilibration_replica_mdins"],
-            remd_mdins = obj["endstate_arguments"]["remd_mdins"]
+            remd_mdins = obj["endstate_arguments"]["remd_mdins"],
+            nthreads_complex = obj["endstate_arguments"]["nthreads_complex"],
+            nthreads_receptor=obj["endstate_arguments"]["nthreads_receptor"],
+            nthreads_ligand=obj["endstate_arguments"]["nthreads_ligand"]
             )
 
 @dataclass
@@ -300,9 +309,7 @@ if __name__ == "__main__":
     config_object = Config.from_config(config)
     
    
-    for con_force in config_object.intermidate_args.conformational_restraints_forces:
-        
-        print(con_force)
+    print(config_object.endstate_method.remd_args)
     # print(new_workflow)
     # print(config_object.workflow)
     # import yaml

--- a/implicit_solvent_ddm/implicit_ddm_workflow.py
+++ b/implicit_solvent_ddm/implicit_ddm_workflow.py
@@ -164,12 +164,12 @@ def ddm_workflow(
                         },
                     )
                 )
-
+                #config.endstate_method.remd_args.nthreads
                 equilibrate_complex = minimization_complex.addFollowOn(
                     REMDSimulation(
                         config.system_settings.executable,
                         config.system_settings.mpi_command,
-                        config.endstate_method.remd_args.nthreads,
+                        config.endstate_method.remd_args.nthreads_complex,
                         config.endstate_files.complex_parameter_filename,
                         minimization_complex.rv(0),
                         config.endstate_method.remd_args.equilibration_replica_mdins,
@@ -187,7 +187,7 @@ def ddm_workflow(
                     REMDSimulation(
                         config.system_settings.executable,
                         config.system_settings.mpi_command,
-                        config.endstate_method.remd_args.nthreads,
+                        config.endstate_method.remd_args.nthreads_complex,
                         config.endstate_files.complex_parameter_filename,
                         equilibrate_complex.rv(0),
                         config.endstate_method.remd_args.remd_mdins,
@@ -234,7 +234,7 @@ def ddm_workflow(
                     REMDSimulation(
                         config.system_settings.executable,
                         config.system_settings.mpi_command,
-                        config.endstate_method.remd_args.nthreads,
+                        config.endstate_method.remd_args.nthreads_ligand,
                         config.endstate_files.ligand_parameter_filename,
                         minimization_ligand.rv(0),
                         config.endstate_method.remd_args.equilibration_replica_mdins,
@@ -252,7 +252,7 @@ def ddm_workflow(
                     REMDSimulation(
                         config.system_settings.executable,
                         config.system_settings.mpi_command,
-                        config.endstate_method.remd_args.nthreads,
+                        config.endstate_method.remd_args.nthreads_ligand,
                         config.endstate_files.ligand_parameter_filename,
                         equilibrate_ligand.rv(0),
                         config.endstate_method.remd_args.remd_mdins,
@@ -298,7 +298,7 @@ def ddm_workflow(
                         REMDSimulation(
                             config.system_settings.executable,
                             config.system_settings.mpi_command,
-                            config.endstate_method.remd_args.nthreads,
+                            config.endstate_method.remd_args.nthreads_receptor,
                             config.endstate_files.receptor_parameter_filename,
                             minimization_receptor.rv(0),
                             config.endstate_method.remd_args.equilibration_replica_mdins,
@@ -316,7 +316,7 @@ def ddm_workflow(
                         REMDSimulation(
                             config.system_settings.executable,
                             config.system_settings.mpi_command,
-                            config.endstate_method.remd_args.nthreads,
+                            config.endstate_method.remd_args.nthreads_receptor,
                             config.endstate_files.receptor_parameter_filename,
                             equilibrate_receptor.rv(0),
                             config.endstate_method.remd_args.remd_mdins,


### PR DESCRIPTION
When running REMD exchange the user can specify the number of cores for each system ligand, receptor & complex

- Ran into a error when the user specified more cores than number of residues for the ligand system. The reason was due to the config file use the same number of cores for the end state simulation which cause the Error: "Running multisander Must have more residues than processors!"

## Solution 
new flag specified in the configuration file 
- nthreads_ligand: int
- nthreads_receptor: int 
- nthreads_complex: int 


## Status
- [x] Ready to go