### PR TITLE
Toil version update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@
 Development of python command-line interface to simplify an absolute binding free energy cycle 
 """
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
+
 import versioneer
 
 short_description = __doc__.split("\n")
@@ -50,7 +52,7 @@ setup(
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # url='http://www.my_package.com',  # Website
-    install_requires=['toil[cwl]'],              # Required packages, pulls from pip if needed; do not use for Conda deployment
+    install_requires=['toil[cwl]<=5.7.1'],              # Required packages, pulls from pip if needed; do not use for Conda deployment
     # platforms=['Linux',
     #            'Mac OS-X',
     #            'Unix',


### PR DESCRIPTION
Toil 5.8.1 released and incorporated permable node attribute in TOIL Job class

Need to modify source code to work with the newer version

For now project workflow only support version 5.7.1

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go