### PR TITLE
COM Restraint Array Limit Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ run_implicit_ddm.py file:/path/to/job-store \
 - **Enhanced Documentation** - Comprehensive guides and examples
 - **Improved Workflow** - Better error handling and recovery
 
+## 🐛 Bug Fixes in v1.1.3
+
+- **Fixed Fortran Crashes** - Resolved COM restraint array overflow issues in large protein systems
+- **Optimized Memory Usage** - Reduced restraint array size by 10-100x through better atom selection
+- **Enhanced Stability** - Improved handling of complex systems with thousands of atoms
+
 ---
 
 **For detailed information, examples, and API reference, visit our [complete documentation]([https://luchkolab.github.io/Impicit-Solvent-DDM/](https://impicit-solvent-ddm.readthedocs.io/en/latest/examples/basic_md_example.html).**

--- a/RELEASE_NOTES_v1.1.3.md
+++ b/RELEASE_NOTES_v1.1.3.md
@@ -3,19 +3,24 @@
 ## Critical Bug Fixes
 
 ### COM Restraint Array Limit Fix
-This release addresses a critical Fortran crash issue in flat-bottom restraints caused by excessive atom selection in the `igr1` list:
+This release addresses critical Fortran crashes in flat-bottom restraints caused by excessive atom selection in the `igr1` list:
 
-- **Fixed Fortran Array Overflow**: Limited receptor atom selection to CA atoms only (`@CA`) to prevent Fortran crashes
+- **Fixed Fortran Array Overflow**: Limited receptor atom selection to CA atoms only (`@CA`) for protein-like systems to prevent Fortran crashes
 - **Optimized Ligand Selection**: Restricted ligand atom selection to heavy atoms only (`!@H*`) to reduce array size
 - **Fixed COM Restraint Template**: Updated restraint template format to prevent parsing errors
-- **Prevented Memory Issues**: Significantly reduced the number of atoms in restraint calculations
+- **Prevented Memory Issues**: Significantly reduced the number of atoms in restraint calculations (10-100x reduction)
 
 #### Technical Details
 The fix addresses the core issue where:
 - **Before**: All receptor atoms were selected (`self.receptor_mask`), potentially including thousands of atoms
-- **After**: Only CA atoms are selected (`self.receptor_mask & @CA`), typically 10-100x fewer atoms
+- **After**: Only CA atoms are selected for protein-like systems (`self.receptor_mask & @CA`), typically 10-100x fewer atoms
 - **Before**: All ligand atoms were selected (`self.ligand_mask`), including hydrogens
 - **After**: Only heavy atoms are selected (`self.ligand_mask & !@H*`), reducing array size
+
+#### System Detection Logic
+Added intelligent system detection:
+- **Protein-like systems**: Contains Cα atoms → use receptor Cα atoms only
+- **Host-guest systems**: No Cα atoms → use all heavy atoms for receptor
 
 #### Template Format Fix
 Updated the COM restraint template to use proper AMBER format:
@@ -26,6 +31,14 @@ Updated the COM restraint template to use proper AMBER format:
 + /
 ```
 
+### GPU Configuration Fixes
+- **Fixed GPU Limit**: Limited `num_accelerators` to 1 to prevent multi-GPU conflicts
+- **GPU Stability**: Ensured only one GPU per simulation to avoid resource conflicts
+
+### Post-Processing Improvements
+- **Fixed File Cleanup**: Prevented premature deletion of mdout files during post-processing
+- **Enhanced Export**: Improved file export handling for simulation outputs
+
 ## Improvements
 
 ### Restraint Generation
@@ -33,11 +46,18 @@ Updated the COM restraint template to use proper AMBER format:
 - **Reduced Computational Overhead**: Fewer atoms in restraint calculations improve performance
 - **Better Memory Management**: Prevents memory allocation issues in large systems
 - **Improved Stability**: Eliminates Fortran array limit crashes in complex systems
+- **Intelligent System Detection**: Automatically detects protein vs host-guest systems
 
 ### Code Quality
 - **Cleaner Template Format**: Standardized restraint template formatting
 - **Better Error Handling**: Improved robustness in restraint generation
 - **Optimized Selection Logic**: More efficient atom selection algorithms
+- **Enhanced Logging**: Added detailed logging for restraint atom selection
+
+### Conformational Restraints
+- **Flat-Bottom Enhancement**: Added configurable flat-bottom width (`delta_flat = 0.5`)
+- **Distance Range**: Restraints now use distance ranges instead of single values
+- **Better Template**: Updated conformational restraint template format
 
 ## Performance Improvements
 
@@ -50,18 +70,21 @@ Updated the COM restraint template to use proper AMBER format:
 - **Large Protein Support**: Now handles systems with thousands of atoms without Fortran crashes
 - **Complex Ligand Support**: Better handling of large ligand molecules
 - **Improved Reliability**: More stable restraint generation across different system sizes
+- **Host-Guest Systems**: Proper handling of small molecule systems
 
 ## Configuration Changes
 
 ### Breaking Changes
-- **Atom Selection**: Receptor restraints now use CA atoms only (previously all atoms)
+- **Atom Selection**: Receptor restraints now use CA atoms only for protein-like systems (previously all atoms)
 - **Template Format**: Updated COM restraint template format for better AMBER compatibility
+- **GPU Limitation**: `num_accelerators` is now limited to 1 to prevent conflicts
 
 ### Migration Guide
 For existing configurations:
 1. No configuration changes required - the fix is automatic
 2. Restraint generation will be more efficient and stable
 3. Large systems that previously crashed will now work correctly
+4. GPU configurations will be automatically limited to 1 accelerator
 
 ## Testing & Validation
 
@@ -69,52 +92,25 @@ For existing configurations:
 - **Re-enabled Workflow Tests**: Fixed and re-enabled comprehensive workflow tests
 - **Large System Testing**: Added validation for systems that previously caused Fortran crashes
 - **Restraint Generation Testing**: Verified proper atom selection and template generation
+- **System Type Detection**: Validated protein vs host-guest system detection
 
 ## Full Changelog
 
 ### Commits in this Release
+- `2d4b5d8` - Fixed restrained atom selection for flat-bottom restraints. If the system is protein-like (contains Cα atoms), select receptor Cα atoms. Otherwise, assume a small host–guest system and select all heavy atoms for the receptor.
+- `6833f54` - Fixed restrained atom selection for flat-bottom restraints. If the system is protein-like (contains Cα atoms), select receptor Cα atoms. Otherwise, assume a small host–guest system and select all heavy atoms for the receptor.
+- `68cc562` - Section on bug fixes
+- `2e3b8bc` - Release v1.1.3: Fix COM restraint array limit - Fix Fortran crashes by limiting receptor atoms to CA only (@CA) - Limit ligand atoms to heavy atoms only () - Update COM restraint template format - Reduce memory usage 10-100x in restraint calculations - Add comprehensive release notes
 - `d0702b9` - Merge branch 'main' into fix/com-restraint-array-limit
-- `138f8ce` - Merge pull request #97 from LuchkoLab/patch/fix-gpu-distribution
-- `bf8f639` - Merge branch 'main' into patch/fix-gpu-distribution
-- `5ca786b` - fix: resolve GPU multi-process bug and improve GPU distribution
-- `165520c` - Merge pull request #96 from LuchkoLab/patch/fix-gpu-distribution
 - `943ffbe` - Merge branch 'patch/fix-gpu-distribution' into fix/com-restraint-array-limit
-- `019dc50` - Fix GPU underutilization by removing mpiexec from pmemd.cuda runs
-- `f14f659` - feat: implement GPU batching with sequential execution per GPU
 - `ade1c28` - Fixed merge issues within config.py, accepted the main branch changes
 - `1c915a5` - feat: enhance restraint generation and GPU job scheduling
+- `f34b778` - Fix Fortran crash during post-processing energy analysis
 
 ### Key Files Modified
 - `implicit_solvent_ddm/restraints.py` - Fixed atom selection for COM restraints (CA atoms only for receptor, heavy atoms only for ligand)
 - `implicit_solvent_ddm/templates/restraints/COM.restraint` - Updated template format
-- `implicit_solvent_ddm/runner.py` - Enhanced GPU job distribution and sequential execution
-- `implicit_solvent_ddm/config.py` - Fixed default GPU count and MPI command handling
-- `implicit_solvent_ddm/simulations.py` - Fixed CUDA execution list handling
-- `implicit_solvent_ddm/alchemical.py` - Standardized system naming
-
-## Dependencies & Environment
-
-### System Requirements
-- **AMBER**: Requires AMBER 18+ with CUDA support
-- **Python**: Python 3.7+ required
-- **CUDA**: CUDA 10.0+ for GPU acceleration
-- **Memory**: Optimized for large protein systems
-
-## Performance Impact
-
-### Before Fix
-- **Issue**: Fortran crashes with large protein systems (>1000 atoms)
-- **Memory**: High memory usage due to excessive atom selection
-- **Stability**: Frequent crashes in complex systems
-
-### After Fix
-- **Stability**: No more Fortran crashes in large systems
-- **Memory**: 10-100x reduction in restraint array size
-- **Performance**: Faster restraint generation and better scalability
-
----
-
-**Version**: 1.1.3  
-**Release Type**: Critical Bug Fix Release  
-**Compatibility**: Python 3.7+, AMBER 18+, CUDA 10.0+  
-**Critical**: This release fixes Fortran crashes that prevented simulation of large protein systems
+- `implicit_solvent_ddm/templates/restraints/conformational_restraints.template` - Enhanced flat-bottom restraints
+- `implicit_solvent_ddm/config.py` - Fixed GPU accelerator limit
+- `implicit_solvent_ddm/postTreatment.py` - Fixed file cleanup issues
+- `implicit_solvent_ddm/simulations.py` - Improved file export handling

--- a/RELEASE_NOTES_v1.1.3.md
+++ b/RELEASE_NOTES_v1.1.3.md
@@ -1,0 +1,120 @@
+# Release Notes - Implicit Solvent DDM v1.1.3
+
+## Critical Bug Fixes
+
+### COM Restraint Array Limit Fix
+This release addresses a critical Fortran crash issue in flat-bottom restraints caused by excessive atom selection in the `igr1` list:
+
+- **Fixed Fortran Array Overflow**: Limited receptor atom selection to CA atoms only (`@CA`) to prevent Fortran crashes
+- **Optimized Ligand Selection**: Restricted ligand atom selection to heavy atoms only (`!@H*`) to reduce array size
+- **Fixed COM Restraint Template**: Updated restraint template format to prevent parsing errors
+- **Prevented Memory Issues**: Significantly reduced the number of atoms in restraint calculations
+
+#### Technical Details
+The fix addresses the core issue where:
+- **Before**: All receptor atoms were selected (`self.receptor_mask`), potentially including thousands of atoms
+- **After**: Only CA atoms are selected (`self.receptor_mask & @CA`), typically 10-100x fewer atoms
+- **Before**: All ligand atoms were selected (`self.ligand_mask`), including hydrogens
+- **After**: Only heavy atoms are selected (`self.ligand_mask & !@H*`), reducing array size
+
+#### Template Format Fix
+Updated the COM restraint template to use proper AMBER format:
+```diff
+- iat = -1,-2
++ iat=-1,-1,
+- &end
++ /
+```
+
+## Improvements
+
+### Restraint Generation
+- **Enhanced Atom Selection**: More precise atom selection for restraint calculations
+- **Reduced Computational Overhead**: Fewer atoms in restraint calculations improve performance
+- **Better Memory Management**: Prevents memory allocation issues in large systems
+- **Improved Stability**: Eliminates Fortran array limit crashes in complex systems
+
+### Code Quality
+- **Cleaner Template Format**: Standardized restraint template formatting
+- **Better Error Handling**: Improved robustness in restraint generation
+- **Optimized Selection Logic**: More efficient atom selection algorithms
+
+## Performance Improvements
+
+### Memory Usage
+- **Reduced Memory Footprint**: Significantly lower memory usage for restraint calculations
+- **Faster Restraint Generation**: Optimized atom selection improves generation speed
+- **Better Scalability**: Handles larger protein systems without crashes
+
+### System Compatibility
+- **Large Protein Support**: Now handles systems with thousands of atoms without Fortran crashes
+- **Complex Ligand Support**: Better handling of large ligand molecules
+- **Improved Reliability**: More stable restraint generation across different system sizes
+
+## Configuration Changes
+
+### Breaking Changes
+- **Atom Selection**: Receptor restraints now use CA atoms only (previously all atoms)
+- **Template Format**: Updated COM restraint template format for better AMBER compatibility
+
+### Migration Guide
+For existing configurations:
+1. No configuration changes required - the fix is automatic
+2. Restraint generation will be more efficient and stable
+3. Large systems that previously crashed will now work correctly
+
+## Testing & Validation
+
+### Test Updates
+- **Re-enabled Workflow Tests**: Fixed and re-enabled comprehensive workflow tests
+- **Large System Testing**: Added validation for systems that previously caused Fortran crashes
+- **Restraint Generation Testing**: Verified proper atom selection and template generation
+
+## Full Changelog
+
+### Commits in this Release
+- `d0702b9` - Merge branch 'main' into fix/com-restraint-array-limit
+- `138f8ce` - Merge pull request #97 from LuchkoLab/patch/fix-gpu-distribution
+- `bf8f639` - Merge branch 'main' into patch/fix-gpu-distribution
+- `5ca786b` - fix: resolve GPU multi-process bug and improve GPU distribution
+- `165520c` - Merge pull request #96 from LuchkoLab/patch/fix-gpu-distribution
+- `943ffbe` - Merge branch 'patch/fix-gpu-distribution' into fix/com-restraint-array-limit
+- `019dc50` - Fix GPU underutilization by removing mpiexec from pmemd.cuda runs
+- `f14f659` - feat: implement GPU batching with sequential execution per GPU
+- `ade1c28` - Fixed merge issues within config.py, accepted the main branch changes
+- `1c915a5` - feat: enhance restraint generation and GPU job scheduling
+
+### Key Files Modified
+- `implicit_solvent_ddm/restraints.py` - Fixed atom selection for COM restraints (CA atoms only for receptor, heavy atoms only for ligand)
+- `implicit_solvent_ddm/templates/restraints/COM.restraint` - Updated template format
+- `implicit_solvent_ddm/runner.py` - Enhanced GPU job distribution and sequential execution
+- `implicit_solvent_ddm/config.py` - Fixed default GPU count and MPI command handling
+- `implicit_solvent_ddm/simulations.py` - Fixed CUDA execution list handling
+- `implicit_solvent_ddm/alchemical.py` - Standardized system naming
+
+## Dependencies & Environment
+
+### System Requirements
+- **AMBER**: Requires AMBER 18+ with CUDA support
+- **Python**: Python 3.7+ required
+- **CUDA**: CUDA 10.0+ for GPU acceleration
+- **Memory**: Optimized for large protein systems
+
+## Performance Impact
+
+### Before Fix
+- **Issue**: Fortran crashes with large protein systems (>1000 atoms)
+- **Memory**: High memory usage due to excessive atom selection
+- **Stability**: Frequent crashes in complex systems
+
+### After Fix
+- **Stability**: No more Fortran crashes in large systems
+- **Memory**: 10-100x reduction in restraint array size
+- **Performance**: Faster restraint generation and better scalability
+
+---
+
+**Version**: 1.1.3  
+**Release Type**: Critical Bug Fix Release  
+**Compatibility**: Python 3.7+, AMBER 18+, CUDA 10.0+  
+**Critical**: This release fixes Fortran crashes that prevented simulation of large protein systems

--- a/implicit_solvent_ddm/config.py
+++ b/implicit_solvent_ddm/config.py
@@ -153,7 +153,9 @@ class SystemSettings:
                 self.num_accelerators = len(cuda.gpus)
             except ImportError:
                 raise RuntimeError("CUDA requested but 'cuda' module not available.")
-
+        if self.num_accelerators > 1:
+            self.num_accelerators = 1
+            # Only use one GPU per simulation 
     @property
     def top_directory_path(self):
         return os.path.join(self.working_directory, self.output_directory_name)

--- a/implicit_solvent_ddm/postTreatment.py
+++ b/implicit_solvent_ddm/postTreatment.py
@@ -377,7 +377,7 @@ def create_mdout_dataframe(
         )
         # data.to_parquet(f"{output_dir}/simulation_mdout.zip",  compression="gzip")
 
-    if os.path.exists(mdout):
-        os.remove(mdout)
+    # if os.path.exists(mdout):
+    #     os.remove(mdout)
 
     return data

--- a/implicit_solvent_ddm/restraints.py
+++ b/implicit_solvent_ddm/restraints.py
@@ -384,6 +384,7 @@ class FlatBottom(Job):
         temp_file = fileStore.getLocalTempFile()
         # protein-like case 
         if self._protein_like:
+            fileStore.logToMaster("Protein-like system: using receptor Cα atoms for flat-bottom restraints."); 
             with open(temp_file, "w") as fH:
                 fH.write(self.generate_flatbottom_restraint)
 
@@ -393,13 +394,15 @@ class FlatBottom(Job):
             )
 
         # non-protein case 
-        with open(temp_file, "w") as fH:
-            fH.write(self._flat_bottom_restraints_template)
+        else:
+            fileStore.logToMaster(" Non-protein case: select all heavy atoms for flat-bottom restraints."); 
+            with open(temp_file, "w") as fH:
+                fH.write(self._flat_bottom_restraints_template)
 
-        return (
-            fileStore.writeGlobalFile(temp_file),
-            self._flat_bottom_restraints_template,
-        )
+            return (
+                fileStore.writeGlobalFile(temp_file),
+                self._flat_bottom_restraints_template,
+            )
 
 class BoreschRestraints(Job):
     """

--- a/implicit_solvent_ddm/simulations.py
+++ b/implicit_solvent_ddm/simulations.py
@@ -264,14 +264,17 @@ class Calculation(Job):
             # for not don't export any data
             # return fileStore.writeGlobalFile("mdout", cleanup=True),
 
-            fileStore.export_file(
-                fileStore.writeGlobalFile("mdout", cleanup=True),
-                "file://"
-                + os.path.abspath(
-                    os.path.join(self.output_dir, os.path.basename("mdout"))
-                ),
+            # fileStore.export_file(
+            #     fileStore.writeGlobalFile("mdout", cleanup=True),
+            #     "file://"
+            #     + os.path.abspath(
+            #         os.path.join(self.output_dir, os.path.basename("mdout"))
+            #     ),
+            # )
+            # Export all ouput files from MD simulation
+            restart_ID, trajectory_ID = self.export_files(
+                fileStore, self.output_dir, files_in_current_directory
             )
-            # Don't need the trajectories from post analysis
             return
 
         else:

--- a/implicit_solvent_ddm/templates/restraints/COM.restraint
+++ b/implicit_solvent_ddm/templates/restraints/COM.restraint
@@ -1,8 +1,7 @@
 &rst
   iresid=0,
-  iat = -1,-2
-  r1=$r1,r2=$r2,r3=$r3,r4=$r4,rk2=$rk2,rk3=$rk3
+  iat=-1,-1,
+  r1=$r1, r2=$r2, r3=$r3, r4=$r4, rk2=$rk2, rk3=$rk3,
   igr1=$host_atom_numbers,
   igr2=$guest_atom_numbers
-&end
 /

--- a/implicit_solvent_ddm/templates/restraints/COM.restraint
+++ b/implicit_solvent_ddm/templates/restraints/COM.restraint
@@ -1,7 +1,8 @@
 &rst
   iresid=0,
-  iat=-1,-1,
-  r1=$r1, r2=$r2, r3=$r3, r4=$r4, rk2=$rk2, rk3=$rk3,
+  iat = -1,-1
+  r1=$r1,r2=$r2,r3=$r3,r4=$r4,rk2=$rk2,rk3=$rk3
   igr1=$host_atom_numbers,
   igr2=$guest_atom_numbers
+&end
 /

--- a/implicit_solvent_ddm/templates/restraints/conformational_restraints.template
+++ b/implicit_solvent_ddm/templates/restraints/conformational_restraints.template
@@ -1,5 +1,5 @@
 
 &rst iat = $solute_primary_atom, $solute_sec_atom,
-r1=0, r2 = $distance, r3 = $distance, r4 = 1000
+r1=0, r2 = $distance_lower, r3 = $distance_upper, r4 = 1000
 rk2=$frest, rk3=$frest,
 /

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     # version=versioneer.get_version(),
-    version="1.1.2",
+    version="1.1.3",
     # cmdclass=versioneer.get_cmdclass(),
     license="MIT",
     # Which Python importable modules should be included when your package is installed


### PR DESCRIPTION
### COM Restraint Array Limit Fix
This release addresses a critical Fortran crash issue in flat-bottom restraints caused by excessive atom selection in the `igr1` list:

- **Fixed Fortran Array Overflow**: Limited receptor atom selection to CA atoms only (`@CA`) to prevent Fortran crashes
- **Optimized Ligand Selection**: Restricted ligand atom selection to heavy atoms only (`!@H*`) to reduce array size
- **Fixed COM Restraint Template**: Updated restraint template format to prevent parsing errors
- **Prevented Memory Issues**: Significantly reduced the number of atoms in restraint calculations

#### Technical Details
The fix addresses the core issue where:
- **Before**: All receptor atoms were selected (`self.receptor_mask`), potentially including thousands of atoms
- **After**: Only CA atoms are selected (`self.receptor_mask & @CA`), typically 10-100x fewer atoms
- **Before**: All ligand atoms were selected (`self.ligand_mask`), including hydrogens
- **After**: Only heavy atoms are selected (`self.ligand_mask & !@H*`), reducing array size